### PR TITLE
Fix: Add accessCheck(FALSE) to entity queries

### DIFF
--- a/src/Commands/YoutubeTranscriptCommands.php
+++ b/src/Commands/YoutubeTranscriptCommands.php
@@ -23,7 +23,10 @@ class YoutubeTranscriptCommands extends DrushCommands {
    * @command youtube_transcript:fetch
    */
   public function fetchTranscripts() {
-    $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['vid' => 'badges']);
+    $query = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->getQuery();
+    $query->condition('vid', 'badges')->accessCheck(FALSE);
+    $tids = $query->execute();
+    $terms = Term::loadMultiple($tids);
     foreach ($terms as $term) {
       $this->fetcher->fetchAndStoreTranscript($term);
     }

--- a/src/Form/YoutubeTranscriptConfigForm.php
+++ b/src/Form/YoutubeTranscriptConfigForm.php
@@ -178,6 +178,7 @@ class YoutubeTranscriptConfigForm extends ConfigFormBase {
     $ids = \Drupal::entityQuery('taxonomy_term')
       ->condition('vid', 'badges')
       ->sort('tid', 'ASC')
+      ->accessCheck(FALSE)
       ->execute();
 
     $total = count($ids);


### PR DESCRIPTION
Resolves a `Drupal\Core\Entity\Query\QueryException` that occurs when fetching transcripts. Entity queries in recent Drupal versions must explicitly state whether access should be checked.

This change adds `.accessCheck(FALSE)` to the entity queries in both the configuration form (`YoutubeTranscriptConfigForm.php`) and the Drush command (`YoutubeTranscriptCommands.php`) to ensure they can run without permission errors in a backend context.